### PR TITLE
Doprecyzowanie błędów RPC i możliwość ponownego ładowania

### DIFF
--- a/moonbeam_contract_monitor.html
+++ b/moonbeam_contract_monitor.html
@@ -236,6 +236,27 @@
             text-align: center;
         }
 
+        .error-message .technical-detail {
+            margin-top: 8px;
+            font-size: 0.85rem;
+            color: #fecaca;
+        }
+
+        .retry-button {
+            margin-top: 10px;
+            padding: 8px 16px;
+            border: none;
+            background: #1e293b;
+            color: #e2e8f0;
+            cursor: pointer;
+            border-radius: 8px;
+            transition: background 0.3s;
+        }
+
+        .retry-button:hover {
+            background: #334155;
+        }
+
         .empty-state {
             text-align: center;
             padding: 40px;
@@ -519,12 +540,19 @@
                 }
             }
 
-            showError(message) {
+            showError(friendlyMessage, technicalDetail) {
                 this.elements.errorContainer.innerHTML = `
                     <div class="error-message">
-                        <strong>Błąd:</strong> ${message}
+                        <div><strong>Błąd:</strong> ${friendlyMessage}</div>
+                        <div class="technical-detail">${technicalDetail}</div>
+                        <button class="retry-button">Spróbuj ponownie</button>
                     </div>
                 `;
+
+                const retry = this.elements.errorContainer.querySelector('.retry-button');
+                if (retry) {
+                    retry.addEventListener('click', () => this.loadTransactionData());
+                }
             }
 
             hideError() {
@@ -568,7 +596,7 @@
                         errorMessage = error.message;
                     }
                     
-                    this.showError(errorMessage);
+                    this.showError(errorMessage, error.message);
                 } finally {
                     this.setLoading(false);
                 }
@@ -800,9 +828,9 @@
                         return data.result;
 
                     } catch (error) {
-                        console.log(`❌ RPC ${rpcIndex + 1} nie działa: ${error.message}`);
-                        lastError = error;
-                        
+                        console.log(`❌ RPC ${rpcIndex + 1} nie działa (${method}): ${error.message}`);
+                        lastError = new Error(`RPC ${rpcUrl} (${method}): ${error.message}`);
+
                         // Add delay before trying next endpoint
                         await new Promise(resolve => setTimeout(resolve, 200));
                     }


### PR DESCRIPTION
## Summary
- Wyświetlanie technicznych szczegółów błędów RPC wraz z informacjami o endpointach i metodach
- Przyjazny komunikat błędu z przyciskiem **Spróbuj ponownie** do ponownego pobrania danych
- Dodany styl dla szczegółów błędów i przycisku ponawiania

## Testing
- `npm test` *(brak konfiguracji testów)*

------
https://chatgpt.com/codex/tasks/task_e_68b051c34824832f83fb8590c893f26b