### PR TITLE
feat: add data versioning and reset option

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,20 @@
             flex-wrap: wrap;
         }
 
+        #resetData {
+            background: #374151;
+            border: none;
+            color: #e2e8f0;
+            padding: 10px 15px;
+            border-radius: 8px;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        #resetData:hover {
+            background: #4b5563;
+        }
+
         #addressSearch {
             padding: 10px 15px;
             border-radius: 8px;
@@ -355,6 +369,7 @@
                     <div class="toggle-slider"></div>
                 </div>
             </div>
+            <button id="resetData">Załaduj od początku</button>
             <div class="status">
                 <span id="statusText">Inicjalizacja...</span>
                 <div id="loadingSpinner" class="spinner"></div>

--- a/moonbeam_contract_monitor.js
+++ b/moonbeam_contract_monitor.js
@@ -1,3 +1,5 @@
+const DATA_VERSION = 1;
+
 class MoonbeamContractMonitor {
     constructor() {
         this.contractAddress = '0x86c66061a0e55d91c8bfa464fe84dc58f8733253';
@@ -55,7 +57,8 @@ class MoonbeamContractMonitor {
             rankHeader: document.getElementById('rankHeader'),
             addressHeader: document.getElementById('addressHeader'),
             txCountHeader: document.getElementById('txCountHeader'),
-            addressSearch: document.getElementById('addressSearch')
+            addressSearch: document.getElementById('addressSearch'),
+            resetButton: document.getElementById('resetData')
         };
     }
 
@@ -77,6 +80,16 @@ class MoonbeamContractMonitor {
                 this.currentPage++;
                 this.displayTable();
             }
+        });
+
+        this.elements.resetButton.addEventListener('click', () => {
+            this.transactionData.clear();
+            this.lastFetchedBlock = 0;
+            this.saveState();
+            this.prepareDisplayData();
+            this.displayTable();
+            this.updateMetrics();
+            this.loadTransactionData();
         });
 
         // Sortowanie kolumn
@@ -127,6 +140,14 @@ class MoonbeamContractMonitor {
 
     loadState() {
         try {
+            const storedVersion = parseInt(localStorage.getItem('dataVersion') || '0', 10);
+            if (!storedVersion || storedVersion < DATA_VERSION) {
+                this.transactionData = new Map();
+                this.lastFetchedBlock = 0;
+                this.saveState();
+                return;
+            }
+
             const savedData = localStorage.getItem('transactionData');
             if (savedData) {
                 const parsed = JSON.parse(savedData);
@@ -150,6 +171,7 @@ class MoonbeamContractMonitor {
             const serialized = JSON.stringify(Object.fromEntries(this.transactionData));
             localStorage.setItem('transactionData', serialized);
             localStorage.setItem('lastFetchedBlock', this.lastFetchedBlock.toString());
+            localStorage.setItem('dataVersion', DATA_VERSION.toString());
         } catch (error) {
             console.error('Error saving state to localStorage:', error);
         }


### PR DESCRIPTION
## Summary
- version stored state with DATA_VERSION constant
- clear stored transactions when version mismatches
- allow reloading data from start via reset button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a9b88308832f82683c3995154cfc