### PR TITLE
Add daily transaction history tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,6 +347,27 @@
                 flex-wrap: wrap;
             }
         }
+
+        .daily-transactions {
+            background: #1e293b;
+            margin: 30px 0;
+            padding: 20px;
+            border-radius: 8px;
+        }
+
+        .daily-transactions h2 {
+            color: #60a5fa;
+            margin-bottom: 15px;
+        }
+
+        .daily-transactions ul {
+            list-style: none;
+        }
+
+        .daily-transactions li {
+            margin-bottom: 8px;
+            color: #e2e8f0;
+        }
     </style>
 </head>
 <body>
@@ -389,6 +410,11 @@
                 <div class="metric-value" id="lastUpdate">-</div>
                 <div class="metric-label">Ostatnia aktualizacja</div>
             </div>
+        </div>
+
+        <div class="daily-transactions">
+            <h2>Transakcje wg dni od wdrożenia</h2>
+            <ul id="dailyTransactionsList"></ul>
         </div>
 
         <div id="errorContainer"></div>


### PR DESCRIPTION
## Summary
- Track contract transactions grouped by day since deployment
- Persist and restore daily transaction data from local storage
- Display daily transaction breakdown in UI

## Testing
- `npm test`
- `node --check moonbeam_contract_monitor.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0c2b74194832f827ad2d38554adca