### PR TITLE
feat: add refresh button and progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
             flex-wrap: wrap;
         }
 
-        #resetData {
+        #resetData, #refreshData {
             background: #374151;
             border: none;
             color: #e2e8f0;
@@ -65,7 +65,7 @@
             transition: background 0.2s;
         }
 
-        #resetData:hover {
+        #resetData:hover, #refreshData:hover {
             background: #4b5563;
         }
 
@@ -312,6 +312,23 @@
             font-weight: 500;
         }
 
+        .progress-bar {
+            height: 4px;
+            background: #1e293b;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 1000;
+        }
+
+        .progress-bar-fill {
+            height: 100%;
+            background: linear-gradient(90deg, #2563eb, #60a5fa);
+            width: 0;
+            transition: width 0.3s;
+        }
+
         @media (max-width: 768px) {
             body {
                 padding: 15px;
@@ -350,6 +367,9 @@
     </style>
 </head>
 <body>
+    <div class="progress-bar">
+        <div class="progress-bar-fill" id="progressBar"></div>
+    </div>
     <div class="container">
         <div class="header">
             <h1>Moonbeam Contract Monitor</h1>
@@ -369,6 +389,7 @@
                     <div class="toggle-slider"></div>
                 </div>
             </div>
+            <button id="refreshData">Odśwież dane</button>
             <button id="resetData">Załaduj od początku</button>
             <div class="status">
                 <span id="statusText">Inicjalizacja...</span>

--- a/moonbeam_contract_monitor.js
+++ b/moonbeam_contract_monitor.js
@@ -58,7 +58,9 @@ class MoonbeamContractMonitor {
             addressHeader: document.getElementById('addressHeader'),
             txCountHeader: document.getElementById('txCountHeader'),
             addressSearch: document.getElementById('addressSearch'),
-            resetButton: document.getElementById('resetData')
+            resetButton: document.getElementById('resetData'),
+            refreshButton: document.getElementById('refreshData'),
+            progressBar: document.getElementById('progressBar')
         };
     }
 
@@ -80,6 +82,10 @@ class MoonbeamContractMonitor {
                 this.currentPage++;
                 this.displayTable();
             }
+        });
+
+        this.elements.refreshButton.addEventListener('click', () => {
+            this.loadTransactionData();
         });
 
         this.elements.resetButton.addEventListener('click', () => {
@@ -213,6 +219,12 @@ class MoonbeamContractMonitor {
             const count = this.transactionData.size;
             const total = Array.from(this.transactionData.values()).reduce((sum, count) => sum + count, 0);
             this.elements.statusText.textContent = `${count} adresów, ${total} transakcji`;
+        }
+    }
+
+    updateProgress(percent) {
+        if (this.elements.progressBar) {
+            this.elements.progressBar.style.width = `${percent}%`;
         }
     }
 
@@ -390,6 +402,10 @@ class MoonbeamContractMonitor {
             return transactions;
         }
 
+        const totalBlocks = latestBlock - fromBlock + 1;
+        let processedBlocks = 0;
+        this.updateProgress(0);
+
         let currentFromBlock = fromBlock;
         while (currentFromBlock <= latestBlock) {
             const batchToBlock = Math.min(currentFromBlock + batchSize - 1, latestBlock);
@@ -422,6 +438,9 @@ class MoonbeamContractMonitor {
                 }
             }
 
+            processedBlocks += (batchToBlock - currentFromBlock + 1);
+            this.updateProgress((processedBlocks / totalBlocks) * 100);
+
             currentFromBlock = batchToBlock + 1;
 
             // Add delay to avoid rate limiting
@@ -435,6 +454,8 @@ class MoonbeamContractMonitor {
         }
 
         this.lastFetchedBlock = latestBlock;
+        this.updateProgress(100);
+        setTimeout(() => this.updateProgress(0), 500);
         console.log(`🎉 Pobieranie zakończone: ${transactions.length} unikalnych transakcji`);
         return transactions;
     }


### PR DESCRIPTION
## Summary
- add manual refresh button for transaction data
- introduce top progress bar to visualize RPC fetch progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1de8e5154832f976b773e5788b059