### PR TITLE
Use unitedbloc RPC and remove Moonscan

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@
             <div class="contract-address">0x86c66061a0e55d91c8bfa464fe84dc58f8733253</div>
             <div style="background: #1e293b; padding: 10px; border-radius: 8px; margin-top: 10px; font-size: 0.85rem; color: #94a3b8; text-align: left;">
                 <strong style="color: #10b981;">✅ LIVE MODE:</strong> Używa prawdziwych danych z Moonbeam RPC<br>
-                🔗 Endpoints: rpc.api.moonbeam.network, ankr.com, 1rpc.io i inne<br>
+                🔗 Endpoints: moonbeam.unitedbloc.com:2000, blastapi.io, rpc.api.moonbeam.network, ankr.com, 1rpc.io<br>
                 📊 Pobiera wszystkie transakcje do kontraktu za pomocą eth_getLogs
             </div>
         </div>


### PR DESCRIPTION
## Summary
- start history from block 11354233 using `DEPLOY_BLOCK`
- prioritize unitedbloc RPC and drop Moonscan API usage
- update landing page text with new RPC endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e8e40010832f8704da8155d3c20b